### PR TITLE
API generiek: max_tokens/max_completion_tokens verwijderd, geen model…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 === AI Translate ===
 Contributors: gkanters  
-Tags: translation, multilingual, woocommerce, seo, artificial intelligence, ai
+Tags: translation, multilingual, woocommerce, seo, artificial intelligence 
 Requires at least: 5.0  
 Tested up to: 6.9  
 Stable tag: 2.2.3

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -2419,10 +2419,6 @@ add_action('wp_ajax_ai_translate_get_models', function () {
         return is_array($m) && isset($m['id']) ? $m['id'] : (is_string($m) ? $m : null);
     }, $data['data']);
     $models = array_filter($models);
-    // Block only o1/o3 (no reasoning_effort support); gpt-5 models allowed
-    $models = array_filter($models, function($model) {
-        return !preg_match('/^(o1-|o3-)/i', $model);
-    });
     sort($models);
     wp_send_json_success(['models' => $models]);
 });

--- a/includes/class-ai-batch.php
+++ b/includes/class-ai-batch.php
@@ -9,8 +9,6 @@ final class AI_Batch
 {
     /**
      * Translate a plan's segments using configured provider.
-     * GPT-5 models use reasoning_effort=minimal for fast translations.
-     * Blocked: o1, o3 (no reasoning_effort parameter support).
      *
      * @param array $plan
      * @param string|null $source
@@ -36,11 +34,6 @@ final class AI_Batch
         $model = $provider !== '' ? ($models[$provider] ?? '') : '';
         $apiKeys = isset($settings['api_keys']) && is_array($settings['api_keys']) ? $settings['api_keys'] : [];
         $apiKey = $provider !== '' ? ($apiKeys[$provider] ?? '') : '';
-
-        // Block o1/o3 reasoning models: they don't support reasoning_effort parameter
-        if ($model !== '' && preg_match('/^(o1-|o3-)/i', $model)) {
-            return ['segments' => [], 'map' => []];
-        }
 
         if (empty($segments)) {
             return ['segments' => [], 'map' => []];
@@ -203,18 +196,7 @@ final class AI_Batch
                             ['role' => 'user', 'content' => $userPayload],
                         ],
                     ];
-                    // Newer models (gpt-5.x, o1-series, o3-series) and DeepSeek v3.2 use max_completion_tokens instead of max_tokens
-                    // These models also don't support temperature != 1, so we omit it
-                    if (str_starts_with($model, 'gpt-5') || str_starts_with($model, 'o1-') || str_starts_with($model, 'o3-') || str_starts_with($model, 'deepseek/deepseek-v3')) {
-                        $body['max_completion_tokens'] = 4096;
-                        // GPT-5 models: use minimal reasoning for translations (fast, no extended thinking)
-                        if (str_starts_with($model, 'gpt-5')) {
-                            $body['reasoning_effort'] = 'minimal';
-                        }
-                    } else {
-                        $body['max_tokens'] = 4096;
-                        $body['temperature'] = 0;
-                    }
+                    $body['temperature'] = 0;
                     $headers = [ 'Authorization' => 'Bearer ' . $apiKey, 'Content-Type' => 'application/json' ];
                     // OpenRouter requires Referer header (WordPress adds HTTP- prefix automatically)
                     if ($provider === 'openrouter' || ($provider === 'custom' && isset($settings['custom_api_url']) && strpos($settings['custom_api_url'], 'openrouter.ai') !== false)) {
@@ -244,17 +226,7 @@ final class AI_Batch
                         $batchesSingle = [$batchSegs];
                         foreach ($batchesSingle as $i => $batchSegs2) {
                             $userPayload = self::buildUserPayload($batchSegs2);
-                            $body = [ 'model' => $model, 'messages' => [ ['role' => 'system', 'content' => $system], ['role' => 'user', 'content' => $userPayload] ] ];
-                            if (str_starts_with($model, 'gpt-5') || str_starts_with($model, 'o1-') || str_starts_with($model, 'o3-') || str_starts_with($model, 'deepseek/deepseek-v3')) {
-                                $body['max_completion_tokens'] = 4096;
-                                // GPT-5 models: use minimal reasoning for translations (fast, no extended thinking)
-                                if (str_starts_with($model, 'gpt-5')) {
-                                    $body['reasoning_effort'] = 'minimal';
-                                }
-                            } else {
-                                $body['max_tokens'] = 4096;
-                                $body['temperature'] = 0;
-                            }
+                            $body = [ 'model' => $model, 'messages' => [ ['role' => 'system', 'content' => $system], ['role' => 'user', 'content' => $userPayload] ] ];                            $body['temperature'] = 0;
                             $fallbackHeaders = [ 'Authorization' => 'Bearer ' . $apiKey, 'Content-Type' => 'application/json' ];
                             if ($provider === 'custom' && isset($settings['custom_api_url']) && strpos($settings['custom_api_url'], 'openrouter.ai') !== false) {
                                 $fallbackHeaders['Referer'] = home_url();
@@ -459,17 +431,8 @@ final class AI_Batch
                     $retryChunks = array_chunk($retrySegs, 5);
                     foreach ($retryChunks as $rc) {
                         $userPayload = self::buildUserPayload($rc);
-                        $body = [ 'model' => $model, 'messages' => [ ['role' => 'system', 'content' => $strictSystem], ['role' => 'user', 'content' => $userPayload] ] ];
-                        if (str_starts_with($model, 'gpt-5') || str_starts_with($model, 'o1-') || str_starts_with($model, 'o3-') || str_starts_with($model, 'deepseek/deepseek-v3')) {
-                            $body['max_completion_tokens'] = 4096;
-                            // GPT-5 models: use minimal reasoning for translations (fast, no extended thinking)
-                            if (str_starts_with($model, 'gpt-5')) {
-                                $body['reasoning_effort'] = 'minimal';
-                            }
-                        } else {
-                            $body['max_tokens'] = 4096;
-                            $body['temperature'] = 0;
-                        }
+                        $body = [ 'model' => $model, 'messages' => [ ['role' => 'system', 'content' => $strictSystem], ['role' => 'user', 'content' => $userPayload] ] ];                       
+                        $body['temperature'] = 0;
                         $retryHeaders = [ 'Authorization' => 'Bearer ' . $apiKey, 'Content-Type' => 'application/json' ];
                         if ($provider === 'custom' && isset($settings['custom_api_url']) && strpos($settings['custom_api_url'], 'openrouter.ai') !== false) {
                             $retryHeaders['Referer'] = home_url();
@@ -555,19 +518,7 @@ final class AI_Batch
                     ['role' => 'user', 'content' => $userPayload],
                 ],
             ];
-            // Newer models (gpt-5.x, o1-series, o3-series) use max_completion_tokens instead of max_tokens
-            // DeepSeek v3.2 also uses max_completion_tokens
-            // These models also don't support temperature != 1, so we omit it
-            if (str_starts_with($model, 'gpt-5') || str_starts_with($model, 'o1-') || str_starts_with($model, 'o3-') || str_starts_with($model, 'deepseek/deepseek-v3')) {
-                $body['max_completion_tokens'] = 4096;
-                // GPT-5 models: use minimal reasoning for translations (fast, no extended thinking)
-                if (str_starts_with($model, 'gpt-5')) {
-                    $body['reasoning_effort'] = 'minimal';
-                }
-            } else {
-                $body['max_tokens'] = 4096;
-                $body['temperature'] = 0;
-            }
+            $body['temperature'] = 0;
 
         $timeoutSeconds = 45; // Balanced timeout for sequential fallback (was 60)
             $attempts = 0;
@@ -721,17 +672,8 @@ final class AI_Batch
                 $retryChunks = array_chunk($retrySegs, 5);
                 foreach ($retryChunks as $rc) {
                     $userPayload = self::buildUserPayload($rc);
-                    $body = [ 'model' => $model, 'messages' => [ ['role' => 'system', 'content' => $strictSystem], ['role' => 'user', 'content' => $userPayload] ] ];
-                    if (str_starts_with($model, 'gpt-5') || str_starts_with($model, 'o1-') || str_starts_with($model, 'o3-') || str_starts_with($model, 'deepseek/deepseek-v3')) {
-                        $body['max_completion_tokens'] = 4096;
-                        // GPT-5 models: use minimal reasoning for translations (fast, no extended thinking)
-                        if (str_starts_with($model, 'gpt-5')) {
-                            $body['reasoning_effort'] = 'minimal';
-                        }
-                    } else {
-                        $body['max_tokens'] = 4096;
-                        $body['temperature'] = 0;
-                    }
+                    $body = [ 'model' => $model, 'messages' => [ ['role' => 'system', 'content' => $strictSystem], ['role' => 'user', 'content' => $userPayload] ] ];                    
+                    $body['temperature'] = 0;
                     $seqRetryHeaders = [ 'Authorization' => 'Bearer ' . $apiKey, 'Content-Type' => 'application/json' ];
                     if ($provider === 'custom' && isset($settings['custom_api_url']) && strpos($settings['custom_api_url'], 'openrouter.ai') !== false) {
                         $seqRetryHeaders['Referer'] = home_url();

--- a/includes/class-ai-translate-core.php
+++ b/includes/class-ai-translate-core.php
@@ -161,8 +161,6 @@ final class AI_Translate_Core
                     ['role' => 'user', 'content' => 'Test'],
                 ],
             ];
-            // Chat test: ruime limiet voor alle models inclusief reasoning models
-            $chatBody['max_completion_tokens'] = 10000;
             $chatResp = wp_remote_post($chatEndpoint, [
                 'headers' => $chatHeaders,
                 'timeout' => 20,
@@ -1013,9 +1011,6 @@ final class AI_Translate_Core
                     ],
                 ];
 
-                // Token limits - ruime limiet voor alle models (je betaalt alleen wat je gebruikt)
-                $body['max_completion_tokens'] = 16000;
-
                 $headers = [
                     'Authorization' => 'Bearer ' . $apiKey,
                     'Content-Type'  => 'application/json',
@@ -1165,9 +1160,6 @@ final class AI_Translate_Core
                         ['role' => 'user', 'content' => $prompt],
                     ],
                 ];
-
-                // Token limits - ruime limiet voor alle models (je betaalt alleen wat je gebruikt)
-                $body['max_completion_tokens'] = 16000;
 
                 $headers = [
                     'Authorization' => 'Bearer ' . $apiKey,


### PR DESCRIPTION
…-specifieke code

- Verwijder alle max_tokens en max_completion_tokens; API gebruikt default
- API-validatie werkt weer met alle modellen (o.a. GPT-5 die max_completion_tokens vereist)
- Geen model-specifieke checks (o1/o3, gpt-5, reasoning_effort) meer
- Generate Context from homepage, batch, meta, connection test: geen token-params

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the payload sent to external LLM providers (token/parameter handling), which can affect compatibility, latency, and cost across providers/models despite being a straightforward removal of branching logic.
> 
> **Overview**
> **Makes AI API calls model-agnostic.** Removes all uses of `max_tokens`, `max_completion_tokens`, and `reasoning_effort`, and stops doing model-prefix branching (e.g., `gpt-5`, `o1`, `o3`, DeepSeek) in batch translation requests.
> 
> **Broadens model compatibility.** Admin model listing no longer filters out `o1-*`/`o3-*` models, and core API validation/summarization/meta-generation requests no longer force a high completion-token limit; they now rely on provider defaults.
> 
> Minor metadata tweak: README `Tags` drops the `ai` tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d60a605aef8f66f14e7f56dd547aed41ca8c7c3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->